### PR TITLE
Add tests for Addenda and Entry records with data in the constructor

### DIFF
--- a/TestNachaSharp/SmokeTests.fs
+++ b/TestNachaSharp/SmokeTests.fs
@@ -41,8 +41,31 @@ let ``Create Blank EntryCCD`` () =
     control.RecordTypeCode |> should equal "6"
 
 [<Fact>]
+let ``Create Non-blank EntryCCD`` () =
+    let control =  EntryCCD("", "6some data")
+    control.AllowMutation <- true
+    control.TraceNumber <- "55"
+    control.TraceNumber |> should equal "55"
+
+[<Fact>]
 let ``Create Blank EntryAddenaWildCard`` () =
     let control =  EntryAddendaWildCard(null)
+    control.RecordTypeCode |> should equal "7"
+
+[<Fact>]
+let ``Create Non-blank EntryAddenda05`` () =
+    let control =  EntryAddenda05("705Power of the Dog")
+    control.AllowMutation <- true
+    control.RecordTypeCode <- "7"
+    control.EntrySeqNum <- "5"
+    control.RecordTypeCode |> should equal "7"
+
+[<Fact>]
+let ``Create Non-blank EntryAddenda05 with empty string`` () =
+    let control =  EntryAddenda05 null
+    control.AllowMutation <- true
+    control.RecordTypeCode <- "7"
+    control.EntrySeqNum <- "5"
     control.RecordTypeCode |> should equal "7"
 
 


### PR DESCRIPTION
Fixes: #6 

This PR shows failing tests for issue #6, added to the SmokeTests. The one-line fix in the [`FSharp.Data.FlatFileMeta`](https://github.com/ekonbenefits/FSharp.Data.FlatFileMeta) project fixes these tests (see https://github.com/ekonbenefits/FSharp.Data.FlatFileMeta/pull/5). Once that PR is merged, I'll update this PR with a new reference and the tests should succeed.